### PR TITLE
Use UTC time

### DIFF
--- a/activitywatch/api.py
+++ b/activitywatch/api.py
@@ -7,7 +7,7 @@ from . import utils
 
 
 class ActivityWatchApi(object):
-    _last_heartbeat = datetime.now()
+    _last_heartbeat = datetime.utcnow()
     freq = 10
 
     def __init__(self, client_name, host, port, freq):
@@ -73,7 +73,7 @@ class ActivityWatchApi(object):
             self.create_bucket(bucket_id)
 
     def heartbeat(self, bucket_id, event_data, pulsetime=30):
-        now = datetime.now()
+        now = datetime.utcnow()
 
         if not self._rate_limited(now):
             return


### PR DESCRIPTION
According to the docs: "It should be noted that all timestamps are stored as UTC. Timezone information (UTC offset) is currently discarded." https://docs.activitywatch.net/en/latest/buckets-and-events.html#events
This lead to incorrect data on my machine, where the stored data was a few hours in the future