### PR TITLE
fix global declaration for python 3.6+

### DIFF
--- a/aw-watcher-sublime.py
+++ b/aw-watcher-sublime.py
@@ -43,8 +43,8 @@ def update_connection_status() -> None:
 def sync_settings() -> None:
     updated_debug = SETTINGS.get("debug")
 
+    global DEBUG
     if DEBUG != updated_debug:
-        global DEBUG
         toggle_debugging(updated_debug)
         DEBUG = updated_debug
 


### PR DESCRIPTION
https://pylint.readthedocs.io/en/stable/user_guide/messages/error/used-prior-global-declaration.html